### PR TITLE
Fix null bytes in output file

### DIFF
--- a/Invoke-Obfuscation.ps1
+++ b/Invoke-Obfuscation.ps1
@@ -1494,7 +1494,7 @@ http://www.danielbohannon.com
                     }
                     
                     # Write ObfuscatedCommand out to disk.
-                    $Script:ObfuscatedCommand | Out-File $OutputFilePath
+                    $Script:ObfuscatedCommand | Out-File $OutputFilePath -Encoding ASCII
 
                     If($Script:LauncherApplied -AND (Test-Path $OutputFilePath))
                     {

--- a/Invoke-Obfuscation.ps1
+++ b/Invoke-Obfuscation.ps1
@@ -1494,7 +1494,7 @@ http://www.danielbohannon.com
                     }
                     
                     # Write ObfuscatedCommand out to disk.
-                    Write-Output $Script:ObfuscatedCommand > $OutputFilePath
+                    $Script:ObfuscatedCommand | Out-File $OutputFilePath
 
                     If($Script:LauncherApplied -AND (Test-Path $OutputFilePath))
                     {


### PR DESCRIPTION
Output file contains NULL bytes ([more info](https://stackoverflow.com/questions/3806305/powershell-2-0-generates-nulls-between-characters)). Replaced function for saving the output file.

Example command:

> Invoke-Obfuscation -ScriptPath 'C:\script.ps1' -Command 'String\3,String\1,String\2,Encoding\3,Launcher\ps\0,out C:\obf_script.ps1' -Quiet


Hex view of the output file:
![image](https://user-images.githubusercontent.com/1427046/52525674-1f6d6600-2ca5-11e9-87e3-42b4ba3857b4.png)
