### PR TITLE
Fix Get-AstChildren doesn't work with IfStatementAst

### DIFF
--- a/Out-ObfuscatedAst.ps1
+++ b/Out-ObfuscatedAst.ps1
@@ -5656,9 +5656,11 @@ function Get-AstChildren {
                 }
                 Else {
                     If($PropertyValue.Item1) {
-                        $Collection = For($i = 1; $i -le $PropertyValue.Length ; $i++){ IEX("$" + "PropertyValue.Item" + $i.ToString()) }
-                        If ($Collection -ne $null) {
-                            $Collection
+                        $PropertyValue | ForEach-Object -Process {
+                            $Collection = For($i = 1; $i -le $_.Length ; $i++){ IEX("$" + "PropertyValue.Item" + $i.ToString()) }
+                            If ($Collection -ne $null) {
+                                $Collection
+                            }
                         }
                     }
                 }

--- a/Out-ObfuscatedAst.ps1
+++ b/Out-ObfuscatedAst.ps1
@@ -5655,8 +5655,8 @@ function Get-AstChildren {
                     $Collection
                 }
                 Else {
-                    if($PropertyValue.Item1) {
-                        $Collection = for($i = 1; $i -le $PropertyValue.Length ; $i++){ IEX("$" + "PropertyValue.Item" + $i.ToString()) }
+                    If($PropertyValue.Item1) {
+                        $Collection = For($i = 1; $i -le $PropertyValue.Length ; $i++){ IEX("$" + "PropertyValue.Item" + $i.ToString()) }
                         If ($Collection -ne $null) {
                             $Collection
                         }

--- a/Out-ObfuscatedAst.ps1
+++ b/Out-ObfuscatedAst.ps1
@@ -5654,6 +5654,14 @@ function Get-AstChildren {
                 If ($Collection -ne $null) {
                     $Collection
                 }
+                Else {
+                    if($PropertyValue.Item1) {
+                        $Collection = for($i = 1; $i -le $PropertyValue.Length ; $i++){ IEX("$" + "PropertyValue.Item" + $i.ToString()) }
+                        If ($Collection -ne $null) {
+                            $Collection
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
For example:
Out-ObfuscatedAst -ScriptBlock {
If($true)
{
    $a = 1 + 3 + 4
    $b = 5
    $c = $a + $b
    $d = 8 + 9
    $e = $d
}
}